### PR TITLE
Fix time

### DIFF
--- a/src/desktop/taskbar/time/time.js
+++ b/src/desktop/taskbar/time/time.js
@@ -19,7 +19,7 @@ export default class Time extends Component
         return(
             <div id="time-cont" onClick={()=>{eventDispatcher('Clock')}}>
             <div id="line-1">{this.state.date.getHours()+':'+this.state.date.getMinutes()}</div>
-                <div id="line-2">{this.state.date.getDay() + '-' + eval(this.state.date.getMonth()+1) + '-'+this.state.date.getFullYear()}</div>
+                <div id="line-2">{this.state.date.getDate() + '-' + eval(this.state.date.getMonth()+1) + '-'+this.state.date.getFullYear()}</div>
             </div>
         );
     }


### PR DESCRIPTION
In taskbar clock, i think date-month-year is collect. So I changed getDay() to getDate().
date.getDay() function return Day of week.  
